### PR TITLE
Let Sequel combine ALTER TABLE statements into one rather than chaining them; Update and expand quirks section of readme

### DIFF
--- a/lib/sequel-bigquery.rb
+++ b/lib/sequel-bigquery.rb
@@ -210,11 +210,8 @@ module Sequel
         sql
       end
 
-      # Batch the alter table queries and make sure something is returned to avoid an error related to the return value
-      def apply_alter_table(name, ops)
-        sqls = alter_table_sql_list(name, ops)
-        sqls_joined = (sqls + ['select 1']).join(";\n")
-        execute_ddl(sqls_joined)
+      def supports_combining_alter_table_ops?
+        true
       end
     end
 

--- a/spec/sequel-bigquery_spec.rb
+++ b/spec/sequel-bigquery_spec.rb
@@ -167,4 +167,37 @@ RSpec.describe Sequel::Bigquery do # rubocop:disable RSpec/FilePath
       expect(dataset).to have_received(:query).with(expected_sql)
     end
   end
+
+  describe 'alter table migration' do
+    let(:migrations_dir) { 'spec/support/migrations/alter_table' }
+    let(:expected_sql) do
+      'ALTER TABLE `alter_people` '\
+        'ADD COLUMN `col1` string, '\
+        'ADD COLUMN `col2` string, '\
+        'ADD COLUMN `col3` string, '\
+        'ADD COLUMN `col4` string, '\
+        'ADD COLUMN `col5` string, '\
+        'ADD COLUMN `col6` string, '\
+        'ADD COLUMN `col7` string, '\
+        'ADD COLUMN `col8` string, '\
+        'ADD COLUMN `col9` string, '\
+        'ADD COLUMN `col10` string, '\
+        'ADD COLUMN `col11` string, '\
+        'ADD COLUMN `col12` string'
+    end
+
+    before do
+      recreate_dataset
+
+      allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery)
+      allow(bigquery).to receive(:dataset).and_return(dataset)
+      allow(dataset).to receive(:query).and_call_original
+
+      Sequel::Migrator.run(db, migrations_dir)
+    end
+
+    it 'combines queries into one alter table statement' do
+      expect(dataset).to have_received(:query).with(expected_sql)
+    end
+  end
 end

--- a/spec/support/migrations/alter_table/001_create_and_alter_people_table.rb
+++ b/spec/support/migrations/alter_table/001_create_and_alter_people_table.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:alter_people) do
+      String :a
+    end
+
+    alter_table(:alter_people) do
+      add_column :col1, String
+      add_column :col2, String
+      add_column :col3, String
+      add_column :col4, String
+      add_column :col5, String
+      add_column :col6, String
+      add_column :col7, String
+      add_column :col8, String
+      add_column :col9, String
+      add_column :col10, String
+      add_column :col11, String
+      add_column :col12, String
+    end
+  end
+end


### PR DESCRIPTION
Contributes to https://github.com/ZimbiX/sequel-bigquery/issues/8.

I noticed that BigQuery's `ALTER TABLE` statement actually [accepts multiple `ADD COLUMN` clauses](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#adding_columns). I then discovered that [Sequel's `Database#alter_table_sql_list`](https://github.com/jeremyevans/sequel/blob/f0df3ed458cadd85085ed28b82a6fdbd86e2942a/lib/sequel/database/schema_methods.rb#L509) calls an excitingly-named method, `supports_combining_alter_table_ops?`. It turns out that simply defining this as `true` enables Sequel to intelligently combine `ALTER TABLE` statements into one, which is much better than how we were chaining them!

And unlike chaining, using a single statement counts towards the rate-limit as only a single update operation! :grin:

Sorry, @jpaulgs; you were right to question the separation in https://github.com/ZimbiX/sequel-bigquery/issues/6.

I haven't tested that all the default [`COMBINABLE_ALTER_TABLE_OPS`](https://github.com/jeremyevans/sequel/blob/f0df3ed458cadd85085ed28b82a6fdbd86e2942a/lib/sequel/database/schema_methods.rb#L14) are in fact combinable in BigQuery; but this is a great start, and we can adjust that when/as necessary.