### PR TITLE
Add proper transaction support by using a BigQuery session

### DIFF
--- a/lib/sequel-bigquery.rb
+++ b/lib/sequel-bigquery.rb
@@ -15,18 +15,40 @@ module Sequel
     DATABASE_SETUP = {}.freeze
 
     class Database < Sequel::Database # rubocop:disable Metrics/ClassLength
+      class BigqueryDatasetConnection
+        def initialize(db:, dataset:)
+          @db = db
+          @dataset = dataset
+          @db.send(:log_each, :debug, 'BigqueryDatasetConnection#initialize')
+        end
+
+        def query_with_session_support(sql, log_query: true)
+          @db.send(:log_query, sql) if log_query
+          @db.send(:log_each, :debug,
+            "BigqueryDatasetConnection#query_with_session_support, using session_id: #{@db.bigquery_session_id.inspect}")
+          @dataset.query(sql, session_id: @db.bigquery_session_id)
+        end
+
+        def query_job(*args, **kawrgs)
+          @dataset.query_job(*args, **kawrgs)
+        end
+
+        def ensure_job_succeeded!(job)
+          @dataset.send(:ensure_job_succeeded!, job)
+        end
+      end
+
       set_adapter_scheme :bigquery
 
       def initialize(*args, **kwargs)
         @bigquery_config = kwargs.fetch(:orig_opts)
-        @sql_buffer = []
-        @sql_buffering = false
         super
       end
 
       def connect(*_args)
         log_each(:debug, '#connect')
-        get_or_create_bigquery_dataset
+        dataset = get_or_create_bigquery_dataset
+        BigqueryDatasetConnection.new(db: self, dataset: dataset)
           .tap { log_each(:debug, '#connect end') }
       end
 
@@ -51,11 +73,9 @@ module Sequel
       end
       alias drop_dataset drop_datasets
 
-      def execute(sql, opts = OPTS) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def execute(sql, opts = OPTS) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
         log_each(:debug, '#execute')
         log_query(sql)
-
-        # require 'pry'; binding.pry if sql =~ /CREATE TABLE IF NOT EXISTS/i
 
         sql = sql.gsub(/\sdefault \S+/i) do
           warn_default_removal(sql)
@@ -67,22 +87,9 @@ module Sequel
           sql += ' where 1 = 1'
         end
 
-        if /^begin/i.match?(sql)
-          warn_transaction
-          @sql_buffering = true
-        end
-
-        if @sql_buffering
-          @sql_buffer << sql
-          return [] unless /^commit/i.match?(sql)
-          warn("Warning: Will now execute entire buffered transaction:\n" + @sql_buffer.join("\n"))
-        end
-
-        sql_to_execute = @sql_buffer.any? ? @sql_buffer.join("\n") : sql
-
         synchronize(opts[:server]) do |conn|
           results = log_connection_yield(sql, conn) do
-            conn.query(sql_to_execute)
+            conn.query_with_session_support(sql, log_query: false)
           end
           log_each(:debug, results.awesome_inspect)
           if block_given?
@@ -93,7 +100,7 @@ module Sequel
         rescue Google::Cloud::InvalidArgumentError, Google::Cloud::PermissionDeniedError => e
           if e.message.include?('too many table update operations for this table')
             warn('Triggered rate limit of table update operations for this table. For more information, see https://cloud.google.com/bigquery/docs/troubleshoot-quotas')
-            if retryable_query?(sql_to_execute)
+            if retryable_query?(sql)
               warn('Detected retryable query - re-running query after a 1 second sleep')
               sleep 1
               retry
@@ -104,11 +111,14 @@ module Sequel
           raise_error(e)
         rescue ArgumentError => e
           raise_error(e)
-        end # rubocop:disable Style/MultilineBlockChain
-          .tap do
-            @sql_buffer = []
-            @sql_buffering = false
-          end
+        end
+      end
+
+      def transaction(*)
+        warn('#transaction start')
+        super
+      ensure
+        warn('#transaction end')
       end
 
       def supports_create_table_if_not_exists?
@@ -127,9 +137,26 @@ module Sequel
         :float64
       end
 
+      def bigquery_session_id
+        # @bigquery_session_id #if in_transaction?
+        @bigquery_session_id ||= synchronize(opts[:server]) do |conn|
+          create_bigquery_session(conn)
+        end
+      end
+
       private
 
       attr_reader :bigquery_config
+
+      # Unfortunately, google-cloud-bigquery doesn't provide a way to create a session by itself; so we have create one by running a query. But Google::Cloud::Bigquery::Dataset#query doesn't support the create_session argument (only session_id), so we have to basically duplicate the functionality of #query to pass the create_session argument to the lower-level #query_job
+      def create_bigquery_session(conn)
+        log_each(:debug, 'Creating BigQuery session for use in transactions')
+        job = conn.query_job('select 1', create_session: true)
+        job.wait_until_done!
+        conn.ensure_job_succeeded!(job)
+        job.session_id
+          .tap { log_each(:debug, 'Session created') }
+      end
 
       def google_cloud_bigquery_gem_config
         bigquery_config.dup.tap do |config|
@@ -157,7 +184,7 @@ module Sequel
       end
 
       def connection_execute_method
-        :query
+        :query_with_session_support
       end
 
       def database_error_classes
@@ -167,17 +194,6 @@ module Sequel
 
       def dataset_class_default
         Dataset
-      end
-
-      def schema_parse_table(_table_name, _opts)
-        log_each(:debug, Paint['schema_parse_table', :red, :bold])
-        # require 'pry'; binding.pry
-        bigquery.datasets.map do |dataset|
-          [
-            dataset.dataset_id,
-            {},
-          ]
-        end
       end
 
       def disconnect_error?(e, opts) # rubocop:disable Lint/UselessMethodDefinition
@@ -237,6 +253,22 @@ module Sequel
 
       def alter_table_query?(sql)
         sql.match?(/\Aalter table /i)
+      end
+
+      # Appending a SELECT prevents an error due to these queries having no destination table:
+      #   google/cloud/bigquery/query_job.rb:1799:in `destination_table_dataset_id': undefined method `dataset_id' for nil:NilClass (NoMethodError)
+      # See https://github.com/googleapis/google-cloud-ruby/issues/9617
+
+      def begin_transaction_sql
+        'BEGIN; SELECT 1'
+      end
+
+      def commit_transaction_sql
+        'COMMIT; SELECT 1'
+      end
+
+      def rollback_transaction_sql
+        'ROLLBACK; SELECT 1'
       end
     end
 


### PR DESCRIPTION
Contributes to https://github.com/ZimbiX/sequel-bigquery/issues/11 and https://github.com/ZimbiX/sequel-bigquery/issues/12.

Currently this uses the one session for every query, but the docs say that prevents concurrency. They also say a session gets deleted after 24 hours, which I think would mean that limiting the use of the single session to transactions would cause still problems for an app with greater uptime than that. I think I need to make it create a new session at the start of each top-level transaction, and stop using the session at the end of it.

Sequel::Model:

The implementation of `#schema_parse_table` was incomplete, and so was preventing a Sequel model from being defined (it inspects the table schema). However, it seems that the method isn't actually essential (or at least, isn't anymore?). I don't recall what necessitated implementing it, but removing it does let a Sequel model be defined successfully. For better support, this should probably be added back later with a full implementation.

Note that saving a Sequel model also does work now, but isn't error-free yet:

```
Sequel::Error: can't express [] as a SQL literal
from /home/brendan/Projects/sequel/lib/sequel/dataset/sql.rb:1319:in `literal_other_append'
```

`#transaction` works now, but manually running `begin` probably doesn't, since it lacks the `; select 1` workaround: https://github.com/googleapis/google-cloud-ruby/issues/9617#issuecomment-1074017350.

Todo:

- [ ] Fix saving a Sequel model
- [ ] Use a new session for each top-level transaction
- [ ] Don't use a session outside a transaction
- [ ] Update the readme regarding transactions
- [ ] Support manually running `begin`
- [ ] Consider other transaction isolation levels